### PR TITLE
Updated dockerfile to deploy on top of jboss/wildfly (8.2.0.Final)

### DIFF
--- a/on-wildfly8/Dockerfile
+++ b/on-wildfly8/Dockerfile
@@ -1,20 +1,18 @@
 # Use latest jboss/base-jdk:7 image as the base
-FROM jboss/base-jdk:7
+FROM jboss/wildfly
 
 MAINTAINER Eric Wittmann <eric.wittmann@redhat.com>
 
-ENV WILDFLY_VERSION 8.1.0.Final
 ENV APIMAN_VERSION 1.0.0.Beta1
+ENV WILDFLY_VERSION 8.1.0.Final
 
 RUN cd $HOME \
- && curl http://download.jboss.org/wildfly/$WILDFLY_VERSION/wildfly-$WILDFLY_VERSION.zip -o wildfly-$WILDFLY_VERSION.zip \
- && curl http://downloads.jboss.org/overlord/apiman/$APIMAN_VERSION/apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip -o apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip \
- && unzip wildfly-$WILDFLY_VERSION.zip \
- && unzip apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip \
- && ln -s wildfly-$WILDFLY_VERSION wildfly
+ && curl http://downloads.jboss.org/overlord/apiman/$APIMAN_VERSION/apiman-distro-wildfly8-$APIMAN_VERSION-overlay.zip | bsdtar -xvf- \
+ && cp -Rf $HOME/wildfly-$WILDFLY_VERSION/* $HOME/wildfly \
+ && rm -rf $HOME/wildfly-$WILDFLY_VERSION
 
-# Set the JBOSS_HOME env variable
-ENV JBOSS_HOME /opt/jboss/wildfly
+RUN  /opt/jboss/wildfly/bin/add-user.sh admin admin123! --silent
+
 
 # Set the default command to run on boot
-CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-c", "standalone-apiman.xml"]
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0", "-c", "standalone-apiman.xml"]


### PR DESCRIPTION
I have updated your Dockerfile to layer on top of jboss/wildfly, as less downloads will be needed to people using jboss/wildfly for anything else).

I have modified the CMD to expose also management interface on 0.0.0.0 and added a user (You can remove this step if you think it is a security contraint, but for now I think it can be ok).

As the distribution zip file assumes to be layered on top of wildfly-8.1.0.Final y have to copy the files to wildfly (it is 8.2.0.Final). Options here for next iteration is to not put it into a dir, or use wildfly as dir, to make it more generic, as I assume it works in wildfly 8.1 as well as 8.2 (at least in my very few tests).

Also, as a side note, the instructions for http://www.apiman.io/latest/download.html use old apiman-dt-ui and not apiman-management.
