### PR TITLE
Adds Dockerfile for Vert.x standalone with embedded CLI

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,19 @@
+FROM openjdk:8 AS build
+
+ARG CLI_VERSION="0.3.0"
+ARG RELEASE_TYPE="tag"
+
+COPY files /tmp
+RUN chmod +x /tmp/fetch-source.sh && \
+    /tmp/fetch-source.sh ${CLI_VERSION} ${RELEASE_TYPE}
+
+WORKDIR /tmp/apiman-cli
+RUN chmod +x /tmp/apiman-cli/gradlew && \
+    ./gradlew shadowJar
+
+FROM openjdk:8-jre-alpine
+
+RUN mkdir -p /opt/apiman-cli/lib
+COPY --from=build /tmp/apiman-cli/build/libs/* /opt/apiman-cli/lib/
+
+ENTRYPOINT [ "java", "-jar", "/opt/apiman-cli/lib/apiman-cli.jar" ]

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,26 @@
+apiman cli
+==========
+
+## Usage
+
+To use apiman CLI
+
+    docker run -it apiman/cli [args]
+
+For valid arguments, please see the documentation for [apiman CLI](https://github.com/apiman/apiman-cli)
+
+## Building the image
+
+    docker build -t="apiman/cli" --rm .
+
+### Building from a branch
+
+If you're a developer working on this project, or you want the latest edge version, you can build from a branch of the apiman-cli repository.
+
+To do this, specify the RELEASE_TYPE as 'branch' and the CLI_VERSION as the branch name:
+
+	docker build -t="apiman/cli:beta" --build-arg RELEASE_TYPE=branch --build-arg CLI_VERSION="develop" --rm .
+
+## Image accessible on Docker hub
+
+This image is automatically built and published into [Docker Hub](https://registry.hub.docker.com/u/apiman/cli/).

--- a/cli/files/fetch-source.sh
+++ b/cli/files/fetch-source.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# -lt 2 ]]; then
+	echo "Usage: $( basename $0 ) <CLI_VERSION> <RELEASE_TYPE>"
+	exit 1
+fi
+
+CLI_VERSION="$1"
+RELEASE_TYPE="$2"
+
+case "${RELEASE_TYPE}" in
+    tag)
+        SOURCE_URL="https://codeload.github.com/apiman/apiman-cli/zip/v${CLI_VERSION}"
+        ;;
+    branch)
+        SOURCE_URL="https://codeload.github.com/apiman/apiman-cli/zip/${CLI_VERSION}"
+        ;;
+    *)
+        echo "Release type must be branch or tag"
+		exit 1
+		;;
+esac
+
+echo -e "Downloading source from: ${SOURCE_URL}"
+curl -s ${SOURCE_URL} -o /tmp/apiman-cli.zip
+
+unzip /tmp/apiman-cli.zip -d /tmp
+mv /tmp/apiman-cli-* /tmp/apiman-cli

--- a/vertx-standalone/Dockerfile
+++ b/vertx-standalone/Dockerfile
@@ -1,0 +1,25 @@
+ARG CLI_VERSION="0.3.0"
+FROM apiman/cli:${CLI_VERSION} AS cli
+
+FROM openjdk:8
+
+ARG PLATFORM_VERSION="1.3.1.Final"
+
+RUN useradd -m -d /home/apiman apiman && \
+	mkdir -p /opt/apiman/apis /opt/apiman/declarations /opt/apiman/lib && \
+	chown -R apiman:apiman /home/apiman /opt/apiman
+
+USER apiman
+RUN curl -s http://downloads.jboss.org/apiman/${PLATFORM_VERSION}/apiman-distro-vertx-${PLATFORM_VERSION}.zip -o /tmp/apiman-distro-vertx-${PLATFORM_VERSION}.zip && \
+	unzip /tmp/apiman-distro-vertx-${PLATFORM_VERSION}.zip -d /tmp && \
+	mv /tmp/apiman-distro-vertx-${PLATFORM_VERSION}/* /opt/apiman/
+
+COPY --from=cli --chown=apiman:apiman /opt/apiman-cli/lib/apiman-cli.jar /opt/apiman/lib
+COPY --chown=apiman:apiman files /opt/apiman
+
+RUN chmod +x /opt/apiman/docker-entrypoint.sh
+
+WORKDIR /opt/apiman
+EXPOSE 8081 8082
+
+ENTRYPOINT [ "./docker-entrypoint.sh" ]

--- a/vertx-standalone/README.md
+++ b/vertx-standalone/README.md
@@ -1,0 +1,26 @@
+apiman vertx standalone
+=======================
+
+This Docker image has an embedded apiman CLI, as well as the Vert.x standalone distribution, enabling you to pass it an API declaration to use. See [apiman CLI](https://github.com/apiman/apiman-cli) documentation for syntax.
+
+## Usage
+
+To start up apiman
+
+    docker run -it apiman/vertx-standalone
+
+You may want to map the port(s) so you can access the app
+
+    docker run -it -p 8082:8082 apiman/vertx-standalone
+
+You will want to provide a declaration and a headless configuration
+
+	docker run -it -p 8082:8082 -v $PWD/examples/apis:/opt/apiman/apis -v $PWD/examples/configs:/opt/apiman/configs apiman/vertx-standalone sample.yml
+
+## Building the image
+
+    docker build -t="apiman/vertx-standalone" --rm .
+
+## Image accessible on Docker hub
+
+This image is automatically built and published into [Docker Hub](https://registry.hub.docker.com/u/apiman/vertx-standalone/).

--- a/vertx-standalone/examples/apis/sample.yml
+++ b/vertx-standalone/examples/apis/sample.yml
@@ -1,0 +1,32 @@
+# Simple apiman example
+---
+  system:
+    gateways:
+      - name: "test-gw"
+        description: "Test Gateway"
+        type: "REST"
+        config:
+          endpoint: "http://localhost:8080/apiman-gateway-api"
+          username: "apimanager"
+          password: "apiman123!"
+    plugins:
+      - groupId: "io.apiman.plugins"
+        artifactId: "apiman-plugins-test-policy"
+        version: "1.3.1.Final"
+  org:
+    name: "test"
+    description: "Test organisation"
+    apis:
+      - name: "example"
+        description: "Example API"
+        version: "1.0"
+        published: true
+        config:
+          endpoint: "http://example.com"
+          endpointType: "rest"
+          public: true
+          gateway: "test-gw"
+        policies:
+          - name: "CachingPolicy"
+            config:
+              ttl: 60

--- a/vertx-standalone/examples/configs/conf-standalone.json
+++ b/vertx-standalone/examples/configs/conf-standalone.json
@@ -1,0 +1,276 @@
+{ // Example headless config with ES-based components (e.g. rate-limiting).
+  "variables": {
+    "apiman": {
+      "es": {
+        "protocol": "http",
+        "host": "localhost",
+        "port": 9200,
+        "username": null,
+        "password": null,
+        "timeout": 10000
+      }
+    }
+  },
+
+  "registry": {
+    "class": "io.apiman.gateway.engine.vertx.polling.URILoadingRegistry",
+    "config": {
+      // Path to your apiman JSON config; refer to apiman's documentation for format description.
+      // Supports: file, HTTP & HTTPS.
+      "configUri": "${CONFIG_FILE_PATH}",
+      // For HTTP/HTTPS auth is supported: BASIC, OAUTH2, KEYCLOAKOAUTH2
+      // For more detail refer to the apiman documentation.
+      "auth": "NONE"
+    }
+  },
+
+  // Gateway error writer
+  // A "trace" version of the error writer - comment out/remove this to suppress stack traces
+  // in the JSON/XML payload returned by the gateway when an error occurs.
+  "writers": {
+    "error": {
+      "class": "io.apiman.gateway.engine.impl.TracePolicyErrorWriter",
+      "config": {}
+    }//,
+      // "policy-failure": {
+      //   "class": "",
+      //   "config": {}
+      // }
+  },
+
+  "encrypter": {
+    "class": "io.apiman.gateway.engine.impl.DefaultDataEncrypter",
+    "config": {}
+  },
+
+  "plugin-registry": {
+    "class": "io.apiman.gateway.platforms.vertx3.engine.VertxPluginRegistry",
+    "config": {}
+  },
+
+  "connector-factory": {
+    "class": "io.apiman.gateway.platforms.vertx3.connector.ConnectorFactory",
+    "config": {
+      // -----------------------------------------------
+      // SSL/TLS settings for the gateway connector(s).
+      // -----------------------------------------------
+      "tls": {
+        // Enable devMode for HTTPS connections (gateway trusts any certificate).
+        // This should *NOT* be used in production mode. *Use with great care.*
+        "devMode": true
+
+        // Whether self-signed certificates should be automatically trusted. *Use with great care.*
+        // "allowSelfSigned": false,
+
+        // Whether certificate host checks should be bypassed. *Use with great care.*
+        // "allowAnyHost": false,
+
+        // Trust store contains certificate(s) trusted by gateway.
+        // "trustStore": "/path/to/your/truststore.jks",
+        // "trustStorePassword": "abc123",
+
+        // Key store contains gateway's keys (including private components: keep it safe).
+        // "keyStore": "/path/to/your/keystore.jks",
+        // "keyStorePassword": "abc123",
+
+        // By default all keys can be used (will try all). If alias list provided, will only attempt to use listed keys.
+        // "keyAliases": "mykey,myotherkey",
+
+        // Allowed TLS/SSL protocols and ciphers suites as CSV. Availability will vary depending on your JVM impl.
+        // Uses JVM defaults depending if not explicitly provided.
+        // See: https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html
+        // You may wish to consider global JVM settings by modifying java.security
+        // "allowedProtocols": "TLSv1.2,TLSv1.1",
+        // "allowedCiphers": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,...",
+        // "disallowedCiphers": "..."
+      }
+    }
+  },
+
+  "policy-factory": {
+    "class": "io.apiman.gateway.engine.policy.PolicyFactoryImpl",
+    "config": {}
+  },
+
+  "logger-factory": {
+    "class": "io.apiman.gateway.platforms.vertx3.logging.VertxLoggerDelegate",
+    "config": {}
+  },
+
+  // Elasticsearch Metrics Settings
+  "metrics": {
+    "class": "io.apiman.gateway.engine.es.ESMetrics",
+    "config": {
+      "client": {
+        "type": "jest",
+        "protocol": "${apiman.es.protocol}",
+        "host": "${apiman.es.host}",
+        "port": "${apiman.es.port}",
+        "initialize": true,
+        "username": "${apiman.es.username}",
+        "password": "${apiman.es.password}",
+        "timeout": "${apiman.es.timeout}"
+      }
+    }
+  },
+
+  "components": {
+    // Shared State Component Settings
+    "ISharedStateComponent": {
+      "class": "io.apiman.gateway.engine.es.ESSharedStateComponent",
+      "config": {
+        "client": {
+          "type": "jest",
+          "protocol": "${apiman.es.protocol}",
+          "host": "${apiman.es.host}",
+          "port": "${apiman.es.port}",
+          "initialize": true,
+          "username": "${apiman.es.username}",
+          "password": "${apiman.es.password}",
+          "timeout": "${apiman.es.timeout}"
+        }
+      }
+    },
+
+    // Rate Limiter Component Settings
+    "IRateLimiterComponent": {
+      "class": "io.apiman.gateway.engine.es.ESRateLimiterComponent",
+      "config": {
+        "client": {
+          "type": "jest",
+          "protocol": "${apiman.es.protocol}",
+          "host": "${apiman.es.host}",
+          "port": "${apiman.es.port}",
+          "initialize": true,
+          "username": "${apiman.es.username}",
+          "password": "${apiman.es.password}",
+          "timeout": "${apiman.es.timeout}"
+        }
+      }
+    },
+
+    // Cache Store Component Settings
+    "ICacheStoreComponent": {
+      "class": "io.apiman.gateway.engine.es.ESCacheStoreComponent",
+      "config": {
+        "client": {
+          "type": "jest",
+          "protocol": "${apiman.es.protocol}",
+          "host": "${apiman.es.host}",
+          "port": "${apiman.es.port}",
+          "initialize": true,
+          "username": "${apiman.es.username}",
+          "password": "${apiman.es.password}",
+          "timeout": "${apiman.es.timeout}"
+        }
+      }
+    },
+
+    // Execute Blocking Component
+    "IExecuteBlockingComponent": {
+      "class": "io.apiman.gateway.platforms.vertx3.components.ExecuteBlockingComponentImpl",
+      "config": {}
+    },
+
+    // JDBC Component Settings
+    "IJdbcComponent": {
+      "class": "io.apiman.gateway.platforms.vertx3.components.JdbcClientComponentImpl",
+      "config": {}
+    },
+
+    // LDAP Component Settings
+    "ILdapComponent": {
+      "class": "io.apiman.gateway.platforms.vertx3.components.LdapClientComponentImpl",
+      "config": {}
+    },
+
+    // HTTP Component Settings
+    "IHttpClientComponent": {
+      "class": "io.apiman.gateway.platforms.vertx3.components.HttpClientComponentImpl",
+      "config": {}
+    },
+
+    // Policy Failure Factory Component
+    "IPolicyFailureFactoryComponent": {
+      "class": "io.apiman.gateway.platforms.vertx3.components.PolicyFailureFactoryComponent",
+      "config": {}
+    },
+
+    // Buffer Factory Component
+    "IBufferFactoryComponent": {
+      "class": "io.apiman.gateway.platforms.vertx3.components.BufferFactoryComponentImpl",
+      "config": {}
+    },
+
+    // Periodic Component
+    "IPeriodicComponent": {
+        "class": "io.apiman.gateway.platforms.vertx3.components.PeriodicComponentImpl",
+        "config": {}
+    }
+  },
+
+  // Host-name to bind to for this machine.
+  "hostname": "localhost",
+
+  // You can force a particular endpoint to be reported here (e.g.
+  // if you have some clustered setup with exotic DNS setup)
+  //"publicEndpoint": "localhost",
+
+  // Verticle configuration
+  // Port - The port a given verticle listens on (where relevant)
+  // Count - Number of given verticle type launched, or "auto" for automatic.
+  "verticles": {
+    "http": {
+      "port": 8082,
+      "count": "auto"
+    },
+    // Configure the following SSL section to enable SSL/TLS.
+    "https": {
+      "port": 8443,
+      "count": 0
+    },
+    // The Gateway API; this will be the port to set in the UI.
+    // e.g. http://localhost:8081 or https://gateway.machine:8081
+    // Configure the following SSL section to enable SSL/TLS.
+    "api": {
+      "port": 8081,
+      "count": 1
+    }
+  },
+
+  // SSL configuration to the gateway's *front end* (i.e. client <-> gateway).
+  //  "ssl": {
+  //    "keystore": {
+  //      "path": "/the/keystore/path/here.jks",
+  //      "password": "password-here"
+  //    },
+  //    "truststore": {
+  //      "path": "/the/truststore/path/here.jks",
+  //      "password": "password-here"
+  //    }
+  //  },
+
+  // Gateway API Authentication. See documentation for further possibilities.
+  "auth": {
+    "type": "keycloak",
+    "config": {
+      "flowType": "PASSWORD",
+      "requiredRole": "realm:apipublisher",
+      // Paste and overwrite your Keycloak config here.
+      "realm": "apiman",
+      "realm-public-key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxyG61ohrfJQKNmDA/ePZtqZVpPXjwn3k3T+iWiTvMsxW2+WlnqIEmL5qZ09DMhBH9r50WZRO2gVoCb657Er9x0vfD6GNf/47XU2y33TX8axhP+hSwkv/VViaDlu4jQrfgPWz/FXMjWIZxg1xQS+nOBF2ScCRYWNQ/ZnUNnvrq8dGC2/AlyeYcgDUOdwlJuvgkGlF0QoVPQiRPurR3RwlG+BjL8JB3hbaAZhdJqwqApmGQbcpgLj2tODnlrZnEAp5cPPU/lgqCE1OOp78BAEiE91ZLPl/+D8qDHk+Maz0Io3bkeRZMXPpvtbL3qN+3GlF8Yz264HDSsTNrH+nd19tFQIDAQAB",
+      "auth-server-url": "http://localhost:8080/auth",
+      "ssl-required": "none",
+      "resource": "apiman-gateway-api",
+      // A limitation in the current OAuth2 implementation means a credentials section is required
+      // even if your client is not set to "confidential". Leave this dummy section if you're using non-confidential.
+      "credentials": {
+        "secret": "217b725d-7790-47a7-a3fc-5cf31f92a8db"
+      }
+      // End paste here
+    }
+  },
+
+  // When reporting an API's endpoint, prefer secure (i.e. https). You should probably change this after enabling HTTPS.
+  "preferSecure": false
+}

--- a/vertx-standalone/files/docker-entrypoint.sh
+++ b/vertx-standalone/files/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+API_SRC_DIR="${SCRIPT_DIR}/apis"
+CLI_ARGS= # Nothing, by default
+
+# The combined output file
+export CONFIG_FILE_PATH="/opt/apiman/apis/all.json"
+
+# All declarations
+DECLARATIONS=""
+for DECLARATION_FILE in "$@"; do
+    DECLARATIONS="${DECLARATIONS} --declarationFile ${API_SRC_DIR}/${DECLARATION_FILE}"
+done
+
+# Perform conversion
+java -jar ${SCRIPT_DIR}/lib/apiman-cli.jar \
+      gateway generate headless ${DECLARATIONS} \
+      --outputFile ${CONFIG_FILE_PATH} ${CLI_ARGS}
+
+./apiman-gateway.sh -conf=/opt/apiman/configs/conf-standalone.json


### PR DESCRIPTION
apiman vertx standalone
=======================

This Docker image has an embedded apiman CLI, as well as the Vert.x standalone distribution, enabling you to pass it an API declaration to use.

See [apiman CLI](https://github.com/apiman/apiman-cli) documentation for syntax.

Example providing a declaration and a headless configuration:

    docker run -it -p 8082:8082 \
        -v $PWD/examples/apis:/opt/apiman/apis \
        -v $PWD/examples/configs:/opt/apiman/configs \
        apiman/vertx-standalone sample.yml
