### PR TITLE
build(docker-compose): bump parent to 3.1.0-SNAPSHOT

### DIFF
--- a/docker-compose/pom.xml
+++ b/docker-compose/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.apiman</groupId>
     <artifactId>apiman-docker</artifactId>
-    <version>3.0.0.Final</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>apiman-distro-docker-compose</artifactId>


### PR DESCRIPTION
Fix #117.

Maven couldn't resolve the module